### PR TITLE
Move gmail object from children to parent GmailBaseTool

### DIFF
--- a/langchain/src/tools/gmail/base.ts
+++ b/langchain/src/tools/gmail/base.ts
@@ -40,16 +40,15 @@ export abstract class GmailBaseTool extends Tool {
       throw new Error("Missing GMAIL_PRIVATE_KEY to interact with Gmail");
     }
 
-    this.gmail = this.getGmail(fields.credentials.clientEmail, fields.credentials.privateKey, fields.scopes || []);
+    this.gmail = this.getGmail(
+      fields.credentials.clientEmail,
+      fields.credentials.privateKey,
+      fields.scopes || []
+    );
   }
 
   private getGmail(email: string, key: string, scopes: string[] = []) {
-    const auth = new google.auth.JWT(
-      email,
-      undefined,
-      key,
-      scopes,
-    );
+    const auth = new google.auth.JWT(email, undefined, key, scopes);
 
     return google.gmail({ version: "v1", auth });
   }

--- a/langchain/src/tools/gmail/base.ts
+++ b/langchain/src/tools/gmail/base.ts
@@ -1,4 +1,4 @@
-import { google } from "googleapis";
+import { gmail_v1, google } from "googleapis";
 import { Tool } from "../base.js";
 import { getEnvironmentVariable } from "../../util/env.js";
 
@@ -15,11 +15,7 @@ export abstract class GmailBaseTool extends Tool {
 
   description = "A tool to send and view emails through Gmail";
 
-  protected clientEmail: string;
-
-  protected privateKey: string;
-
-  protected scopes: string[];
+  protected gmail: gmail_v1.Gmail;
 
   constructor(
     fields: GmailBaseToolParams = {
@@ -44,19 +40,17 @@ export abstract class GmailBaseTool extends Tool {
       throw new Error("Missing GMAIL_PRIVATE_KEY to interact with Gmail");
     }
 
-    this.clientEmail = fields.credentials.clientEmail;
-    this.privateKey = fields.credentials.privateKey;
-    this.scopes = fields.scopes || [];
+    this.gmail = this.getGmail(fields.credentials.clientEmail, fields.credentials.privateKey, fields.scopes || []);
   }
 
-  async getAuth() {
+  private getGmail(email: string, key: string, scopes: string[] = []) {
     const auth = new google.auth.JWT(
-      this.clientEmail,
+      email,
       undefined,
-      this.privateKey,
-      this.scopes
+      key,
+      scopes,
     );
 
-    return auth;
+    return google.gmail({ version: "v1", auth });
   }
 }

--- a/langchain/src/tools/gmail/create_draft.ts
+++ b/langchain/src/tools/gmail/create_draft.ts
@@ -1,4 +1,3 @@
-import { google } from "googleapis";
 import { encodeToBase64 } from "@gomomento/sdk-core/dist/src/internal/utils/string.js";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
@@ -48,9 +47,6 @@ export class GmailCreateDraft extends GmailBaseTool {
   }
 
   async _call(args: CreateDraftSchema) {
-    const auth = await this.getAuth();
-
-    const gmail = google.gmail({ version: "v1", auth });
     const { message, to, subject, cc, bcc } = args;
     const create_message = this.prepareDraftMessage(
       message,
@@ -60,7 +56,7 @@ export class GmailCreateDraft extends GmailBaseTool {
       bcc
     );
 
-    const response = await gmail.users.drafts.create({
+    const response = await this.gmail.users.drafts.create({
       userId: "me",
       requestBody: create_message,
     });

--- a/langchain/src/tools/gmail/get_message.ts
+++ b/langchain/src/tools/gmail/get_message.ts
@@ -1,4 +1,3 @@
-import { google } from "googleapis";
 import { GmailBaseToolParams, GmailBaseTool } from "./base.js";
 
 export class GmailGetMessage extends GmailBaseTool {
@@ -11,11 +10,7 @@ export class GmailGetMessage extends GmailBaseTool {
   }
 
   async _call(messageId: string) {
-    const auth = await this.getAuth();
-
-    const gmail = google.gmail({ version: "v1", auth });
-
-    const message = await gmail.users.messages.get({
+    const message = await this.gmail.users.messages.get({
       userId: "me",
       id: messageId,
     });

--- a/langchain/src/tools/gmail/get_thread.ts
+++ b/langchain/src/tools/gmail/get_thread.ts
@@ -1,4 +1,3 @@
-import { google } from "googleapis";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
 export interface GetThreadSchema {
@@ -15,13 +14,9 @@ export class GmailGetThread extends GmailBaseTool {
   }
 
   async _call(args: GetThreadSchema) {
-    const auth = await this.getAuth();
-
-    const gmail = google.gmail({ version: "v1", auth });
-
     const { threadId } = args;
 
-    const thread = await gmail.users.threads.get({
+    const thread = await this.gmail.users.threads.get({
       userId: "me",
       id: threadId,
     });

--- a/langchain/src/tools/gmail/search.ts
+++ b/langchain/src/tools/gmail/search.ts
@@ -1,4 +1,4 @@
-import { gmail_v1, google } from "googleapis";
+import { gmail_v1 } from "googleapis";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
 export interface SearchSchema {
@@ -18,11 +18,9 @@ export class GmailSearch extends GmailBaseTool {
   }
 
   async _call(args: SearchSchema) {
-    const auth = await this.getAuth();
-    const gmail = google.gmail({ version: "v1", auth });
     const { query, maxResults = 10, resource = "messages" } = args;
 
-    const response = await gmail.users.messages.list({
+    const response = await this.gmail.users.messages.list({
       userId: "me",
       q: query,
       maxResults,
@@ -56,11 +54,9 @@ export class GmailSearch extends GmailBaseTool {
   async parseMessages(
     messages: gmail_v1.Schema$Message[]
   ): Promise<gmail_v1.Schema$Message[]> {
-    const auth = await this.getAuth();
-    const gmail = google.gmail({ version: "v1", auth });
     const parsedMessages = await Promise.all(
       messages.map(async (message) => {
-        const messageData = await gmail.users.messages.get({
+        const messageData = await this.gmail.users.messages.get({
           userId: "me",
           format: "raw",
           id: message.id ?? "",
@@ -96,11 +92,9 @@ export class GmailSearch extends GmailBaseTool {
   async parseThreads(
     threads: gmail_v1.Schema$Thread[]
   ): Promise<gmail_v1.Schema$Thread[]> {
-    const auth = await this.getAuth();
-    const gmail = google.gmail({ version: "v1", auth });
     const parsedThreads = await Promise.all(
       threads.map(async (thread) => {
-        const threadData = await gmail.users.threads.get({
+        const threadData = await this.gmail.users.threads.get({
           userId: "me",
           format: "raw",
           id: thread.id ?? "",

--- a/langchain/src/tools/gmail/sent_message.ts
+++ b/langchain/src/tools/gmail/sent_message.ts
@@ -1,4 +1,3 @@
-import { google } from "googleapis";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
 interface SendMessageParams {
@@ -51,9 +50,6 @@ export class GmailSendMessage extends GmailBaseTool {
     cc,
     bcc,
   }: SendMessageParams): Promise<string> {
-    const auth = await this.getAuth();
-    const gmail = google.gmail({ version: "v1", auth });
-
     const rawMessage = this.createEmailMessage({
       message,
       to,
@@ -63,7 +59,7 @@ export class GmailSendMessage extends GmailBaseTool {
     });
 
     try {
-      const response = await gmail.users.messages.send({
+      const response = await this.gmail.users.messages.send({
         userId: "me",
         requestBody: {
           raw: rawMessage,


### PR DESCRIPTION
Before we were repeating the following code in each subclass:
```ts
const auth = await this.getAuth();
const gmail = google.gmail({ version: "v1", auth });
```

This was pointless because we had all the params already in the superclass, so this PR moves the `gmail` object to the parent class so children can just access it through `this.gmail`