### PR TITLE
fix: switched to Buffer class for base64 encode

### DIFF
--- a/langchain/src/tools/gmail/create_draft.ts
+++ b/langchain/src/tools/gmail/create_draft.ts
@@ -1,4 +1,3 @@
-import { encodeToBase64 } from "@gomomento/sdk-core/dist/src/internal/utils/string.js";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
 export interface CreateDraftSchema {
@@ -41,7 +40,7 @@ export class GmailCreateDraft extends GmailBaseTool {
       message,
     ].join("\n");
 
-    draftMessage.message.raw = encodeToBase64(email);
+    draftMessage.message.raw = Buffer.from(email).toString("base64url");
 
     return draftMessage;
   }


### PR DESCRIPTION
Used built in Node.js Buffer class to base64 encode instead of function used previously