### PR TITLE
Make fields optional and use defaults properly in constructor

### DIFF
--- a/langchain/src/tools/gmail/create_draft.ts
+++ b/langchain/src/tools/gmail/create_draft.ts
@@ -15,7 +15,7 @@ export class GmailCreateDraft extends GmailBaseTool {
   description =
     "Use this tool to create a draft email with the provided message fields.";
 
-  constructor(fields: GmailBaseToolParams) {
+  constructor(fields?: GmailBaseToolParams) {
     super(fields);
   }
 

--- a/langchain/src/tools/gmail/get_message.ts
+++ b/langchain/src/tools/gmail/get_message.ts
@@ -5,7 +5,7 @@ export class GmailGetMessage extends GmailBaseTool {
 
   description = "Get a message from Gmail";
 
-  constructor(fields: GmailBaseToolParams) {
+  constructor(fields?: GmailBaseToolParams) {
     super(fields);
   }
 

--- a/langchain/src/tools/gmail/get_thread.ts
+++ b/langchain/src/tools/gmail/get_thread.ts
@@ -9,7 +9,7 @@ export class GmailGetThread extends GmailBaseTool {
 
   description = "Get a thread from Gmail";
 
-  constructor(fields: GmailBaseToolParams) {
+  constructor(fields?: GmailBaseToolParams) {
     super(fields);
   }
 

--- a/langchain/src/tools/gmail/search.ts
+++ b/langchain/src/tools/gmail/search.ts
@@ -13,7 +13,7 @@ export class GmailSearch extends GmailBaseTool {
   description =
     "Use this tool to search for email messages or threads. The input must be a valid Gmail query. The output is a JSON list of the requested resource.";
 
-  constructor(fields: GmailBaseToolParams) {
+  constructor(fields?: GmailBaseToolParams) {
     super(fields);
   }
 

--- a/langchain/src/tools/gmail/sent_message.ts
+++ b/langchain/src/tools/gmail/sent_message.ts
@@ -1,6 +1,6 @@
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
-interface SendMessageParams {
+export interface SendMessageParams {
   message: string;
   to: string | string[];
   subject: string;
@@ -13,7 +13,7 @@ export class GmailSendMessage extends GmailBaseTool {
 
   description = "Send a message using Gmail";
 
-  constructor(fields: GmailBaseToolParams) {
+  constructor(fields?: GmailBaseToolParams) {
     super(fields);
   }
 
@@ -43,7 +43,7 @@ export class GmailSendMessage extends GmailBaseTool {
     return Buffer.from(email).toString("base64url");
   }
 
-  protected async _call({
+  async _call({
     message,
     to,
     subject,


### PR DESCRIPTION
Previously the default values weren't being used in the constructor, this commit fixes that.

Also fields are now optional in each of the gmail tool constructors since they have defaults as backups anyways

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

