### PR TITLE
Add index.ts types, add unit tests

### DIFF
--- a/langchain/src/tools/gmail/get_message.ts
+++ b/langchain/src/tools/gmail/get_message.ts
@@ -1,5 +1,9 @@
 import { GmailBaseToolParams, GmailBaseTool } from "./base.js";
 
+export interface GetMessageSchema {
+  messageId: string;
+}
+
 export class GmailGetMessage extends GmailBaseTool {
   name = "gmail_get_message";
 
@@ -9,7 +13,9 @@ export class GmailGetMessage extends GmailBaseTool {
     super(fields);
   }
 
-  async _call(messageId: string) {
+  async _call(args: GetMessageSchema) {
+    const { messageId } = args;
+
     const message = await this.gmail.users.messages.get({
       userId: "me",
       id: messageId,

--- a/langchain/src/tools/gmail/index.ts
+++ b/langchain/src/tools/gmail/index.ts
@@ -1,0 +1,13 @@
+export { GmailBaseTool } from "./base.js";
+export { GmailCreateDraft } from "./create_draft.js";
+export { GmailGetMessage } from "./get_message.js";
+export { GmailGetThread } from "./get_thread.js";
+export { GmailSearch } from "./search.js";
+export { GmailSendMessage } from "./send_message.js";
+
+export type { GmailBaseToolParams } from "./base.js";
+export type { CreateDraftSchema } from "./create_draft.js";
+export type { GetMessageSchema } from "./get_message.js";
+export type { GetThreadSchema } from "./get_thread.js";
+export type { SearchSchema } from "./search.js";
+export type { SendMessageSchema } from "./send_message.js";

--- a/langchain/src/tools/gmail/send_message.ts
+++ b/langchain/src/tools/gmail/send_message.ts
@@ -1,6 +1,6 @@
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 
-export interface SendMessageParams {
+export interface SendMessageSchema {
   message: string;
   to: string | string[];
   subject: string;
@@ -23,7 +23,7 @@ export class GmailSendMessage extends GmailBaseTool {
     subject,
     cc,
     bcc,
-  }: SendMessageParams): string {
+  }: SendMessageSchema): string {
     const emailLines: string[] = [];
 
     // Format the recipient(s)
@@ -49,7 +49,7 @@ export class GmailSendMessage extends GmailBaseTool {
     subject,
     cc,
     bcc,
-  }: SendMessageParams): Promise<string> {
+  }: SendMessageSchema): Promise<string> {
     const rawMessage = this.createEmailMessage({
       message,
       to,

--- a/langchain/src/tools/tests/gmail.test.ts
+++ b/langchain/src/tools/tests/gmail.test.ts
@@ -1,0 +1,63 @@
+import { jest, expect, describe } from "@jest/globals";
+import { GmailGetMessage } from "../gmail/get_message.js";
+
+jest.mock("googleapis", () => ({
+  google: {
+    auth: {
+      JWT: jest.fn().mockImplementation(() => ({})),
+    },
+  },
+}));
+
+describe("GmailBaseTool using GmailGetMessage", () => {
+  it("should be setup with correct parameters", async () => {
+    const params = {
+      credentials: {
+        clientEmail: "test@email.com",
+        privateKey: "privateKey",
+      },
+      scopes: ["gmail_scope1"],
+    };
+    const instance = new GmailGetMessage(params);
+    expect(instance.name).toBe("gmail_get_message");
+  });
+
+  it("should throw an error if both privateKey and keyfile are missing", async () => {
+    const params = {
+      credentials: {},
+      scopes: ["gmail_scope1"],
+    };
+
+    expect(() => new GmailGetMessage(params)).toThrow();
+  });
+
+  it("should throw error with only client_email", async () => {
+    const params = {
+      credentials: {
+        clientEmail: "client_email",
+      },
+    };
+
+    expect(() => new GmailGetMessage(params)).toThrow();
+  });
+
+  it("should throw error with only private_key", async () => {
+    const params = {
+      credentials: {
+        privateKey: "privateKey",
+      },
+    };
+
+    expect(() => new GmailGetMessage(params)).toThrow();
+  });
+
+  it("should throw error with only keyfile", async () => {
+    const params = {
+      credentials: {
+        keyfile: "keyfile",
+      },
+    };
+
+    expect(() => new GmailGetMessage(params)).toThrow();
+  });
+});


### PR DESCRIPTION
- Add unit tests
  - Can be run using `yarn test:single ./langchain/src/tools/tests/gmail.test.ts`
- Add `tools/gmail/index.ts` that exports all our types in 1 place
- Rename sen**t**_message.ts to sen**d**_message.ts
- Make `get_message.ts` use an interface to define `_call` params instead of just a string
