### PR TITLE
Add gmail type definitions to package.json

### DIFF
--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -67,6 +67,9 @@ tools/sql.d.ts
 tools/webbrowser.cjs
 tools/webbrowser.js
 tools/webbrowser.d.ts
+tools/gmail.cjs
+tools/gmail.js
+tools/gmail.d.ts
 tools/google_calendar.cjs
 tools/google_calendar.js
 tools/google_calendar.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -79,6 +79,9 @@
     "tools/webbrowser.cjs",
     "tools/webbrowser.js",
     "tools/webbrowser.d.ts",
+    "tools/gmail.cjs",
+    "tools/gmail.js",
+    "tools/gmail.d.ts",
     "tools/google_calendar.cjs",
     "tools/google_calendar.js",
     "tools/google_calendar.d.ts",
@@ -1522,6 +1525,11 @@
       "types": "./tools/webbrowser.d.ts",
       "import": "./tools/webbrowser.js",
       "require": "./tools/webbrowser.cjs"
+    },
+    "./tools/gmail": {
+      "types": "./tools/gmail.d.ts",
+      "import": "./tools/gmail.js",
+      "require": "./tools/gmail.cjs"
     },
     "./tools/google_calendar": {
       "types": "./tools/google_calendar.d.ts",


### PR DESCRIPTION
Need these type definitions in package.json for the examples to be able to recognize gmail. With these we can run `yarn start src/tools/gmail.ts` from the examples directory to run the example