### PR TITLE
Gmail toolkit

### DIFF
--- a/examples/src/tools/gmail.ts
+++ b/examples/src/tools/gmail.ts
@@ -1,13 +1,6 @@
 import { initializeAgentExecutorWithOptions } from "langchain/agents";
+import { GmailToolkit } from "langchain/agents/toolkits";
 import { OpenAI } from "langchain/llms/openai";
-import { StructuredTool } from "langchain/tools";
-import {
-  GmailCreateDraft,
-  GmailGetMessage,
-  GmailGetThread,
-  GmailSearch,
-  GmailSendMessage,
-} from "langchain/tools/gmail";
 
 export async function run() {
   const model = new OpenAI({
@@ -24,19 +17,17 @@ export async function run() {
   //     scopes: ["https://mail.google.com/"],
   //   };
 
-  // For custom parameters, uncomment the code above, replace the values with your own, and pass it to the tools below
-  const tools: StructuredTool[] = [
-    new GmailCreateDraft(),
-    new GmailGetMessage(),
-    new GmailGetThread(),
-    new GmailSearch(),
-    new GmailSendMessage(),
-  ];
+  // For custom parameters, uncomment the code above, replace the values with your own, and pass it to the toolkit below
+  const gmailToolkit = new GmailToolkit();
 
-  const gmailAgent = await initializeAgentExecutorWithOptions(tools, model, {
-    agentType: "structured-chat-zero-shot-react-description",
-    verbose: true,
-  });
+  const gmailAgent = await initializeAgentExecutorWithOptions(
+    gmailToolkit.tools,
+    model,
+    {
+      agentType: "zero-shot-react-description",
+      verbose: true,
+    }
+  );
 
   const createInput = `Create a gmail draft for me to edit of a letter from the perspective of a sentient parrot who is looking to collaborate on some research with her estranged friend, a cat. Under no circumstances may you send the message, however.`;
 

--- a/langchain/src/agents/toolkits/gmail.ts
+++ b/langchain/src/agents/toolkits/gmail.ts
@@ -1,0 +1,24 @@
+import { Tool } from "../../tools/base.js";
+import { GmailBaseToolParams } from "../../tools/gmail/base.js";
+import { GmailCreateDraft } from "../../tools/gmail/create_draft.js";
+import { GmailGetMessage } from "../../tools/gmail/get_message.js";
+import { GmailGetThread } from "../../tools/gmail/get_thread.js";
+import { GmailSearch } from "../../tools/gmail/search.js";
+import { GmailSendMessage } from "../../tools/gmail/send_message.js";
+import { Toolkit } from "./base.js";
+
+export class GmailToolkit extends Toolkit {
+  tools: Tool[];
+
+  constructor(fields?: Partial<GmailBaseToolParams>) {
+    super();
+
+    this.tools = [
+      new GmailCreateDraft(fields),
+      new GmailSendMessage(fields),
+      new GmailGetMessage(fields),
+      new GmailGetThread(fields),
+      new GmailSearch(fields),
+    ];
+  }
+}

--- a/langchain/src/agents/toolkits/index.ts
+++ b/langchain/src/agents/toolkits/index.ts
@@ -18,3 +18,4 @@ export {
   type ConversationalRetrievalAgentOptions,
 } from "./conversational_retrieval/openai_functions.js";
 export { OpenAIAgentTokenBufferMemory } from "./conversational_retrieval/token_buffer_memory.js";
+export { GmailToolkit } from "./gmail.js";

--- a/langchain/src/tools/gmail/create_draft.ts
+++ b/langchain/src/tools/gmail/create_draft.ts
@@ -1,16 +1,17 @@
+import { z } from "zod";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 import { CREATE_DRAFT_DESCRIPTION } from "./descriptions.js";
 
-export interface CreateDraftSchema {
-  message: string;
-  to: string[];
-  subject: string;
-  cc?: string[];
-  bcc?: string[];
-}
-
 export class GmailCreateDraft extends GmailBaseTool {
   name = "create_gmail_draft";
+
+  private draftSchema = z.object({
+    message: z.string(),
+    to: z.array(z.string()),
+    subject: z.string(),
+    cc: z.array(z.string()).optional(),
+    bcc: z.array(z.string()).optional(),
+  });
 
   description = CREATE_DRAFT_DESCRIPTION;
 
@@ -45,8 +46,8 @@ export class GmailCreateDraft extends GmailBaseTool {
     return draftMessage;
   }
 
-  async _call(args: CreateDraftSchema) {
-    const { message, to, subject, cc, bcc } = args;
+  async _call(arg: z.output<typeof this.draftSchema>) {
+    const { message, to, subject, cc, bcc } = arg;
     const create_message = this.prepareDraftMessage(
       message,
       to,
@@ -63,3 +64,11 @@ export class GmailCreateDraft extends GmailBaseTool {
     return `Draft created. Draft Id: ${response.data.id}`;
   }
 }
+
+export type CreateDraftSchema = {
+  message: string;
+  to: string[];
+  subject: string;
+  cc?: string[];
+  bcc?: string[];
+};

--- a/langchain/src/tools/gmail/get_message.ts
+++ b/langchain/src/tools/gmail/get_message.ts
@@ -1,12 +1,13 @@
+import { z } from "zod";
 import { GmailBaseToolParams, GmailBaseTool } from "./base.js";
 import { GET_MESSAGE_DESCRIPTION } from "./descriptions.js";
 
-export interface GetMessageSchema {
-  messageId: string;
-}
-
 export class GmailGetMessage extends GmailBaseTool {
   name = "gmail_get_message";
+
+  private getMessageSchema = z.object({
+    messageId: z.string(),
+  });
 
   description = GET_MESSAGE_DESCRIPTION;
 
@@ -14,8 +15,8 @@ export class GmailGetMessage extends GmailBaseTool {
     super(fields);
   }
 
-  async _call(args: GetMessageSchema) {
-    const { messageId } = args;
+  async _call(arg: z.output<typeof this.getMessageSchema>) {
+    const { messageId } = arg;
 
     const message = await this.gmail.users.messages.get({
       userId: "me",
@@ -88,3 +89,7 @@ export class GmailGetMessage extends GmailBaseTool {
     })}`;
   }
 }
+
+export type GetMessageSchema = {
+  messageId: string;
+};

--- a/langchain/src/tools/gmail/get_thread.ts
+++ b/langchain/src/tools/gmail/get_thread.ts
@@ -1,12 +1,13 @@
+import { z } from "zod";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 import { GET_THREAD_DESCRIPTION } from "./descriptions.js";
 
-export interface GetThreadSchema {
-  threadId: string;
-}
-
 export class GmailGetThread extends GmailBaseTool {
   name = "gmail_get_thread";
+
+  private getThreadSchema = z.object({
+    threadId: z.string(),
+  });
 
   description = GET_THREAD_DESCRIPTION;
 
@@ -14,8 +15,8 @@ export class GmailGetThread extends GmailBaseTool {
     super(fields);
   }
 
-  async _call(args: GetThreadSchema) {
-    const { threadId } = args;
+  async _call(arg: z.output<typeof this.getThreadSchema>) {
+    const { threadId } = arg;
 
     const thread = await this.gmail.users.threads.get({
       userId: "me",
@@ -98,3 +99,7 @@ export class GmailGetThread extends GmailBaseTool {
     )}`;
   }
 }
+
+export type GetThreadSchema = {
+  threadId: string;
+};

--- a/langchain/src/tools/gmail/search.ts
+++ b/langchain/src/tools/gmail/search.ts
@@ -1,15 +1,16 @@
 import { gmail_v1 } from "googleapis";
+import { z } from "zod";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 import { SEARCH_DESCRIPTION } from "./descriptions.js";
 
-export interface SearchSchema {
-  query: string;
-  maxResults?: number;
-  resource?: "messages" | "threads";
-}
-
 export class GmailSearch extends GmailBaseTool {
   name = "search_gmail";
+
+  private searchSchema = z.object({
+    query: z.string(),
+    maxResults: z.number().optional(),
+    resource: z.enum(["messages", "threads"]).optional(),
+  });
 
   description = SEARCH_DESCRIPTION;
 
@@ -17,8 +18,8 @@ export class GmailSearch extends GmailBaseTool {
     super(fields);
   }
 
-  async _call(args: SearchSchema) {
-    const { query, maxResults = 10, resource = "messages" } = args;
+  async _call(arg: z.output<typeof this.searchSchema>) {
+    const { query, maxResults = 10, resource = "messages" } = arg;
 
     const response = await this.gmail.users.messages.list({
       userId: "me",
@@ -126,3 +127,9 @@ export class GmailSearch extends GmailBaseTool {
     return parsedThreads;
   }
 }
+
+export type SearchSchema = {
+  query: string;
+  maxResults?: number;
+  resource?: "messages" | "threads";
+};

--- a/langchain/src/tools/gmail/send_message.ts
+++ b/langchain/src/tools/gmail/send_message.ts
@@ -1,16 +1,17 @@
+import { z } from "zod";
 import { GmailBaseTool, GmailBaseToolParams } from "./base.js";
 import { GET_MESSAGE_DESCRIPTION } from "./descriptions.js";
 
-export interface SendMessageSchema {
-  message: string;
-  to: string | string[];
-  subject: string;
-  cc?: string | string[];
-  bcc?: string | string[];
-}
-
 export class GmailSendMessage extends GmailBaseTool {
   name = "gmail_send_message";
+
+  private sendMessageSchema = z.object({
+    message: z.string(),
+    to: z.array(z.string()),
+    subject: z.string(),
+    cc: z.array(z.string()).optional(),
+    bcc: z.array(z.string()).optional(),
+  });
 
   description = GET_MESSAGE_DESCRIPTION;
 
@@ -24,7 +25,7 @@ export class GmailSendMessage extends GmailBaseTool {
     subject,
     cc,
     bcc,
-  }: SendMessageSchema): string {
+  }: z.infer<typeof this.sendMessageSchema>): string {
     const emailLines: string[] = [];
 
     // Format the recipient(s)
@@ -50,7 +51,7 @@ export class GmailSendMessage extends GmailBaseTool {
     subject,
     cc,
     bcc,
-  }: SendMessageSchema): Promise<string> {
+  }: z.output<typeof this.sendMessageSchema>): Promise<string> {
     const rawMessage = this.createEmailMessage({
       message,
       to,
@@ -73,3 +74,11 @@ export class GmailSendMessage extends GmailBaseTool {
     }
   }
 }
+
+export type SendMessageSchema = {
+  message: string;
+  to: string[];
+  subject: string;
+  cc?: string[];
+  bcc?: string[];
+};


### PR DESCRIPTION
Add `GmailToolkit` which just contains a list of all the GmailTools, and updated docs to reflect that.

Needed to change `GmailBaseTool` to extend `Tool` instead of `StructuredTool` since `Toolkit` only works with Tools.

Passed `yarn build` in langchain and unit tests passed and docs successfully ran